### PR TITLE
upgrade to prefect 3.4.22 alongside pycaprio 0.3.0, prefect-dask 0.3.6, dkpro-cassis==0.10.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,9 @@
 - blackbar-shinyproxy
    - blackbar-shinyproxy-3.2.0 added
    - Based on Ubuntu 24.04 and Java 21 adding "-XX:MaxRAMPercentage=50.0", "-XX:MinRAMPercentage=20.0", "-XX:+ExitOnOutOfMemoryError" to java options at startup
+- blackbar-base
+   - Upgrade to prefect 3.4.22
+   - Based on Debian 13 (trixie)
 
 ### Release 0.2.2
 
@@ -97,7 +100,7 @@
 
 ### Release 0.1
 
-- blackbar-base: image based on prefecthq/prefect, version 2.15.0-python3.10 which is based on Ubuntu 20.04
+- blackbar-base: image based on prefecthq/prefect, version 2.15.0-python3.10 which is based on Debian 12 (bookworm)
 - blackbar-base-apps: image based on ghcr.io/bnosac/blackbar-base + shiny and commonly used shiny extensions (rmarkdown/shinydashboard/slib/fontawesome/knitr/reticulate)
 - blackbar-inception-minio: Inception (28.5) and Minio (RELEASE.2024-11-07T00-52-20Z)
 - blackbar-inception-minio-mariadb: Inception (28.5) and Minio (RELEASE.2024-11-07T00-52-20Z) and MariaDB (10.7)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Public docker images for project blackbar
 
 - **blackbar-base**:  
 
-   - Docker image based on prefecthq/prefect, version 2.15.0-python3.10 which is based on Ubuntu 20.04
    - Containing core software for project blackbar
+   - Docker image based on prefecthq/prefect, version 3.4.22-python3.10 which is based on Debian 13 (trixie)
+   - Docker image based on prefecthq/prefect, version 2.15.0-python3.10 which is based on Debian 12 (bookworm)
 
 ```
 docker pull ghcr.io/bnosac/blackbar-base:latest

--- a/anonymization/Dockerfile
+++ b/anonymization/Dockerfile
@@ -1,4 +1,4 @@
-FROM prefecthq/prefect:2.15.0-python3.10
+FROM prefecthq/prefect:3.4.22-python3.10
 LABEL maintainer="BNOSAC blackbar@bnosac.be"
 LABEL org.opencontainers.image.source=https://github.com/bnosac/blackbar-docker
 LABEL org.opencontainers.image.description="Anonymisation and Pseudonymisation - open libraries"

--- a/anonymization/requirements.txt
+++ b/anonymization/requirements.txt
@@ -1,19 +1,19 @@
 pandas==2.3.2
 numpy==2.2.6
-pycaprio @ git+https://github.com/JavierLuna/pycaprio.git@0.2.1#egg=pycaprio
-dkpro-cassis==0.9.1
+pycaprio==0.3.0
+dkpro-cassis==0.10.1
 spacy==3.8.7
 torch==2.8.0
 biopython==1.83.0
 jaydebeapi==1.2.3
 minio==7.2.16
 podman==5.5.0
-attrs==23.2.0
-pydantic==1.10.11
-urllib3==1.26.15
-requests-toolbelt==0.10.1
-prefect==2.15.0
-prefect-dask==0.2.9
+attrs
+pydantic
+urllib3
+requests-toolbelt
+prefect==3.4.22
+prefect-dask==0.3.6
 faker==24.0.0
 dateparser==1.2.0
 babel==2.14.0


### PR DESCRIPTION
upgrade to prefect 3.4.22 alongside pycaprio 0.3.0, prefect-dask 0.3.6, dkpro-cassis==0.10.1