### PR TITLE
edsnlp - cython incompatibility

### DIFF
--- a/anonymization/Dockerfile
+++ b/anonymization/Dockerfile
@@ -29,6 +29,7 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 ##
 COPY requirements.txt .
 RUN python -m pip install --no-cache-dir -r requirements.txt
+RUN python -m pip install edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 
 ####################################################################################################
 ## General settings

--- a/anonymization/requirements.txt
+++ b/anonymization/requirements.txt
@@ -24,7 +24,11 @@ requests==2.31.0
 ## Pseudonymization edge cases
 llama-cpp-python==0.3.8
 ## EDS-NLP modelling
-edsnlp[ml]==0.21.0
+cython
+setuptools
+wheel
+build
+#edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 transformers==4.57.6
 sentencepiece==0.2.1
 flair==0.15.1

--- a/anonymization/requirements.txt
+++ b/anonymization/requirements.txt
@@ -24,10 +24,10 @@ requests==2.31.0
 ## Pseudonymization edge cases
 llama-cpp-python==0.3.8
 ## EDS-NLP modelling
-cython
-setuptools
-wheel
-build
+cython==3.2.4
+setuptools==82.0.1
+wheel==0.47.0
+build==1.5.0
 #edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 transformers==4.57.6
 sentencepiece==0.2.1

--- a/development/rstudio/Dockerfile
+++ b/development/rstudio/Dockerfile
@@ -46,7 +46,7 @@ COPY requirements.txt .
 #RUN python3.10 -m pip install --no-cache-dir -r requirements.txt
 #RUN python3    -m pip install --no-cache-dir -r requirements.txt
 RUN uv pip install --system --no-cache-dir -r requirements.txt
-RUN uv pip install edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
+RUN uv pip install --system edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 RUN uv pip install --system pip
 
 ##

--- a/development/rstudio/Dockerfile
+++ b/development/rstudio/Dockerfile
@@ -46,6 +46,7 @@ COPY requirements.txt .
 #RUN python3.10 -m pip install --no-cache-dir -r requirements.txt
 #RUN python3    -m pip install --no-cache-dir -r requirements.txt
 RUN uv pip install --system --no-cache-dir -r requirements.txt
+RUN uv pip install edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 RUN uv pip install --system pip
 
 ##

--- a/development/rstudio/requirements.txt
+++ b/development/rstudio/requirements.txt
@@ -34,7 +34,11 @@ plotly==6.3.0
 ## Pseudonymization edge cases
 llama-cpp-python==0.3.8
 ## EDS-NLP modelling
-edsnlp[ml]==0.21.0
+cython
+setuptools
+wheel
+build
+#edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 transformers==4.57.6
 sentencepiece==0.2.1
 flair==0.15.1

--- a/development/rstudio/requirements.txt
+++ b/development/rstudio/requirements.txt
@@ -34,10 +34,10 @@ plotly==6.3.0
 ## Pseudonymization edge cases
 llama-cpp-python==0.3.8
 ## EDS-NLP modelling
-cython
-setuptools
-wheel
-build
+cython==3.2.4
+setuptools==82.0.1
+wheel==0.47.0
+build==1.5.0
 #edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 transformers==4.57.6
 sentencepiece==0.2.1

--- a/development/vscode/Dockerfile
+++ b/development/vscode/Dockerfile
@@ -82,6 +82,7 @@ COPY requirements.txt .
 #RUN python3.10 -m pip install --no-cache-dir -r requirements.txt
 #RUN python3    -m pip install --no-cache-dir -r requirements.txt
 RUN uv pip install --system --no-cache-dir -r requirements.txt
+RUN uv pip install edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 RUN uv pip install --system pip
 
 ##

--- a/development/vscode/Dockerfile
+++ b/development/vscode/Dockerfile
@@ -82,7 +82,7 @@ COPY requirements.txt .
 #RUN python3.10 -m pip install --no-cache-dir -r requirements.txt
 #RUN python3    -m pip install --no-cache-dir -r requirements.txt
 RUN uv pip install --system --no-cache-dir -r requirements.txt
-RUN uv pip install edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
+RUN uv pip install --system edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 RUN uv pip install --system pip
 
 ##

--- a/development/vscode/requirements.txt
+++ b/development/vscode/requirements.txt
@@ -24,7 +24,11 @@ requests==2.31.0
 ## Pseudonymization edge cases
 llama-cpp-python==0.3.8
 ## EDS-NLP modelling
-edsnlp[ml]==0.21.0
+cython
+setuptools
+wheel
+build
+#edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 transformers==4.57.6
 sentencepiece==0.2.1
 flair==0.15.1

--- a/development/vscode/requirements.txt
+++ b/development/vscode/requirements.txt
@@ -24,10 +24,10 @@ requests==2.31.0
 ## Pseudonymization edge cases
 llama-cpp-python==0.3.8
 ## EDS-NLP modelling
-cython
-setuptools
-wheel
-build
+cython==3.2.4
+setuptools==82.0.1
+wheel==0.47.0
+build==1.5.0
 #edsnlp[ml]==0.21.0 --no-binary edsnlp --no-build-isolation
 transformers==4.57.6
 sentencepiece==0.2.1


### PR DESCRIPTION
Avoid getting variable spacy.tokens.token.MISSING_DEP has wrong signature (expected int const , got int)) due to edsnlp binary incompatibility with spacy